### PR TITLE
Don't deallocate error messages strings from ORT in Rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
   "example",
   "ort-custom-op",

--- a/ort-custom-op/src/error.rs
+++ b/ort-custom-op/src/error.rs
@@ -1,4 +1,4 @@
-use std::ffi::CString;
+use std::ffi::CStr;
 use std::fmt;
 
 use crate::bindings::{OrtApi, OrtStatus, OrtStatusPtr};
@@ -12,9 +12,12 @@ pub struct ErrorStatusPtr {
 impl ErrorStatusPtr {
     pub fn new(ptr: OrtStatusPtr, api: &OrtApi) -> Self {
         let cstr_ptr = unsafe { api.GetErrorMessage.unwrap()(ptr) };
-        let msg = unsafe { CString::from_raw(cstr_ptr as *mut _) }
-            .into_string()
-            .unwrap();
+        // We must not deallocated the msg string (use CStr rather than CString).
+        let msg = unsafe { CStr::from_ptr(cstr_ptr as *mut _) }
+            .to_str()
+            .unwrap()
+            .to_string();
+
         Self {
             status: unsafe { ptr.as_mut().unwrap() },
             msg,

--- a/tests/python/test_custom.py
+++ b/tests/python/test_custom.py
@@ -81,8 +81,48 @@ def attr_showcase_model():
             "string_attr": "bar",
             "floats_attr": [3.14, 3.14],
             "ints_attr": [42, 42],
-            "u8_tensor": u8_tensor
+            "u8_tensor": u8_tensor,
         },
+    )
+    value_infos_input = [
+        helper.make_value_info(
+            "IN1", helper.make_tensor_type_proto(TensorProto.FLOAT, [])
+        ),
+        helper.make_value_info(
+            "IN2", helper.make_tensor_type_proto(TensorProto.INT64, [])
+        ),
+        helper.make_value_info(
+            "IN3", helper.make_tensor_type_proto(TensorProto.STRING, [])
+        ),
+    ]
+    value_infos_output = [
+        helper.make_value_info(
+            "OUT1", helper.make_tensor_type_proto(TensorProto.FLOAT, [])
+        ),
+        helper.make_value_info(
+            "OUT2", helper.make_tensor_type_proto(TensorProto.INT64, [])
+        ),
+        helper.make_value_info(
+            "OUT3", helper.make_tensor_type_proto(TensorProto.STRING, [])
+        ),
+    ]
+    graph = helper.make_graph(
+        [node],
+        "graph",
+        value_infos_input,
+        value_infos_output,
+    )
+    return helper.make_model(graph, opset_imports=[helper.make_opsetid("my.domain", 1)])
+
+
+@pytest.fixture
+def attr_showcase_model_missing_attributes():
+    """Create a model which lacks all attributes to test the error case."""
+    node = helper.make_node(
+        "AttrShowcase",
+        ["IN1", "IN2", "IN3"],
+        ["OUT1", "OUT2", "OUT3"],
+        domain="my.domain",
     )
     value_infos_input = [
         helper.make_value_info(
@@ -239,6 +279,16 @@ def test_attr_showcase(shared_lib, attr_showcase_model):
     np.testing.assert_equal(a, np.array([3.14], np.float32))
     np.testing.assert_equal(b, [42])
     np.testing.assert_equal(c, ["foo + bar"])
+
+
+@pytest.mark.skip(
+    reason="Crashes the interpreter but prints a decent error message."
+)
+def test_attr_showcase_missing_attrs(
+    shared_lib,
+    attr_showcase_model_missing_attributes,
+):
+    sess = setup_session(shared_lib, attr_showcase_model_missing_attributes)
 
 
 def test_custom_sum(shared_lib, custom_sum_model):


### PR DESCRIPTION
Prior to this PR we had a double-free in the error handling code. This caused a crash with an unhelpful memory corruption error when attempting to access non-existing attributes of a node. Due to the lack of error propagation in the current C-API we still crash after this PR, but at least we now print the correct error message. 