### PR TITLE
Public Input & Output traits

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,14 @@
 Changelog
 =========
 
+0.5.0 (Unreleased)
+------------------
+
+** New feature **
+
+- Input and Output traits are now publicly accessible.
+
+
 0.4.1 (2023-09-14)
 ------------------
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,7 +240,7 @@ checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "ort_custom_op"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "ndarray",

--- a/ort-custom-op/Cargo.toml
+++ b/ort-custom-op/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ort_custom_op"
 description = "A library for writing custom operators for the onnxruntime in Rust."
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
 license = "BSD-3-Clause"
 homepage = "https://github.com/cbourjau/ort-custom-op"

--- a/ort-custom-op/src/inputs.rs
+++ b/ort-custom-op/src/inputs.rs
@@ -27,7 +27,7 @@ pub trait Inputs<'s> {
 
     fn from_ort(api: &OrtApi, ctx: &'s OrtKernelContext) -> Self;
 }
-trait Input<'s> {
+pub trait Input<'s> {
     const INPUT_TYPE: ElementType;
     const CHARACTERISTIC: OrtCustomOpInputOutputCharacteristic;
 

--- a/ort-custom-op/src/outputs.rs
+++ b/ort-custom-op/src/outputs.rs
@@ -21,7 +21,7 @@ pub trait Outputs {
     fn write_to_ort(self, api: &OrtApi, ctx: &mut OrtKernelContext);
 }
 
-trait Output {
+pub trait Output {
     const OUTPUT_TYPE: ElementType;
     const CHARACTERISTIC: OrtCustomOpInputOutputCharacteristic;
 

--- a/tests/python/test_custom.py
+++ b/tests/python/test_custom.py
@@ -237,7 +237,8 @@ def setup_session(shared_lib: Path, model) -> onnxrt.InferenceSession:
 
     # Model loading successfully indicates that the custom op node
     # could be resolved successfully
-    return onnxrt.InferenceSession(model.SerializeToString(), sess_options=so)
+    return onnxrt.InferenceSession(model.SerializeToString(), sess_options=so,
+                                   providers=["CPUExecutionProvider"])
 
 
 def test_custom_add(shared_lib, custom_add_model):


### PR DESCRIPTION
Currently writing implementations of CustomOp "generically" requires a convoluted use of macros. By exposing the traits used to define inputs and outputs this can instead be done much more simply using generics as the user has a valid trait bound.