### PR TITLE
Rewrite of the `Inputs` trait to facilitate having &str input tensor elements rather than Strings

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,14 @@
 Changelog
 =========
 
+0.6.0 (unreleased)
+------------------
+
+**Breaking changes**
+
+- String input tensors are now passed as `ArrayViewD<'_, &str>` objects rather than `ArrayD<String>` objects.
+- The `ort_custom_ops::prelude::KernelInfo.get_attribute_tensors` function now returns owned array objects for numerical data. String tensors are currently not supported.
+
 0.5.1 (2023-11-04)
 ------------------
 

--- a/example/src/add.rs
+++ b/example/src/add.rs
@@ -12,7 +12,7 @@ pub struct CustomAdd<T> {
 impl<T> CustomOp for CustomAdd<T>
 where
     T: 'static + Add<T, Output = T> + Clone,
-    for<'foo> (ArrayViewD<'foo, T>, ArrayViewD<'foo, T>): Inputs<'foo>,
+    for<'a> (ArrayViewD<'a, T>, ArrayViewD<'a, T>): Inputs<'a>,
     (ArrayD<T>,): Outputs,
 {
     type KernelCreateError = Infallible;

--- a/example/src/add.rs
+++ b/example/src/add.rs
@@ -9,10 +9,10 @@ pub struct CustomAdd<T> {
     ty: PhantomData<T>,
 }
 
-impl<'s, T> CustomOp<'s> for CustomAdd<T>
+impl<T> CustomOp for CustomAdd<T>
 where
     T: 'static + Add<T, Output = T> + Clone,
-    (ArrayViewD<'s, T>, ArrayViewD<'s, T>): TryFromValues<'s>,
+    for<'foo> (ArrayViewD<'foo, T>, ArrayViewD<'foo, T>): Inputs<'foo>,
     (ArrayD<T>,): Outputs,
 {
     type KernelCreateError = Infallible;
@@ -20,16 +20,16 @@ where
 
     const NAME: &'static str = "CustomAdd";
 
-    type OpInputs = (ArrayViewD<'s, T>, ArrayViewD<'s, T>);
+    type OpInputs<'s> = (ArrayViewD<'s, T>, ArrayViewD<'s, T>);
     type OpOutputs = (ArrayD<T>,);
 
     fn kernel_create(_info: &KernelInfo) -> Result<Self, Self::KernelCreateError> {
         Ok(CustomAdd { ty: PhantomData })
     }
 
-    fn kernel_compute(
+    fn kernel_compute<'s>(
         &self,
-        (array_x, array_y): Self::OpInputs,
+        (array_x, array_y): Self::OpInputs<'s>,
     ) -> Result<Self::OpOutputs, Self::ComputeError> {
         Ok((&array_x + &array_y,))
     }

--- a/example/src/add.rs
+++ b/example/src/add.rs
@@ -9,10 +9,10 @@ pub struct CustomAdd<T> {
     ty: PhantomData<T>,
 }
 
-impl<'add, T> CustomOp for CustomAdd<T>
+impl<'s, T> CustomOp<'s> for CustomAdd<T>
 where
     T: 'static + Add<T, Output = T> + Clone,
-    for<'s> (ArrayViewD<'s, T>, ArrayViewD<'s, T>): Inputs<'s>,
+    (ArrayViewD<'s, T>, ArrayViewD<'s, T>): TryFromValues<'s>,
     (ArrayD<T>,): Outputs,
 {
     type KernelCreateError = Infallible;
@@ -20,7 +20,7 @@ where
 
     const NAME: &'static str = "CustomAdd";
 
-    type OpInputs<'s> = (ArrayViewD<'s, T>, ArrayViewD<'s, T>);
+    type OpInputs = (ArrayViewD<'s, T>, ArrayViewD<'s, T>);
     type OpOutputs = (ArrayD<T>,);
 
     fn kernel_create(_info: &KernelInfo) -> Result<Self, Self::KernelCreateError> {
@@ -29,7 +29,7 @@ where
 
     fn kernel_compute(
         &self,
-        (array_x, array_y): Self::OpInputs<'_>,
+        (array_x, array_y): Self::OpInputs,
     ) -> Result<Self::OpOutputs, Self::ComputeError> {
         Ok((&array_x + &array_y,))
     }

--- a/example/src/add.rs
+++ b/example/src/add.rs
@@ -27,9 +27,9 @@ where
         Ok(CustomAdd { ty: PhantomData })
     }
 
-    fn kernel_compute<'s>(
+    fn kernel_compute(
         &self,
-        (array_x, array_y): Self::OpInputs<'s>,
+        (array_x, array_y): Self::OpInputs<'_>,
     ) -> Result<Self::OpOutputs, Self::ComputeError> {
         Ok((&array_x + &array_y,))
     }

--- a/example/src/attr_showcase.rs
+++ b/example/src/attr_showcase.rs
@@ -22,7 +22,7 @@ impl CustomOp for AttrShowcase {
 
     const NAME: &'static str = "AttrShowcase";
 
-    type OpInputs<'s> = (ArrayViewD<'s, f32>, ArrayViewD<'s, i64>, ArrayD<String>);
+    type OpInputs<'s> = (ArrayViewD<'s, f32>, ArrayViewD<'s, i64>, ArrayD<&'s str>);
     type OpOutputs = (ArrayD<f32>, ArrayD<i64>, ArrayD<String>);
 
     fn kernel_create(info: &KernelInfo) -> Result<Self, Self::KernelCreateError> {

--- a/example/src/attr_showcase.rs
+++ b/example/src/attr_showcase.rs
@@ -34,7 +34,7 @@ impl CustomOp for AttrShowcase {
             float_attr: info.get_attribute_f32("float_attr")?,
             int_attr: info.get_attribute_i64("int_attr")?,
             string_attr: info.get_attribute_string("string_attr")?,
-            _u8_tensor: info.get_attribute_tensor("u8_tensor")?.to_owned(),
+            _u8_tensor: info.get_attribute_tensor("u8_tensor")?,
             _floats_attr: info.get_attribute_f32s("floats_attr")?,
             _ints_attr: info.get_attribute_i64s("ints_attr")?,
         })
@@ -46,7 +46,7 @@ impl CustomOp for AttrShowcase {
     ) -> Result<Self::OpOutputs, Self::ComputeError> {
         let a = &a + self.float_attr;
         let b = &b + self.int_attr;
-        let c = c.map(|v| v.to_string() + " + " + &self.string_attr);
+        let c = c.mapv(|v| v.to_string() + " + " + &self.string_attr);
         Ok((a, b, c))
     }
 }

--- a/example/src/attr_showcase.rs
+++ b/example/src/attr_showcase.rs
@@ -22,7 +22,11 @@ impl CustomOp for AttrShowcase {
 
     const NAME: &'static str = "AttrShowcase";
 
-    type OpInputs<'s> = (ArrayViewD<'s, f32>, ArrayViewD<'s, i64>, ArrayD<&'s str>);
+    type OpInputs<'s> = (
+        ArrayViewD<'s, f32>,
+        ArrayViewD<'s, i64>,
+        ArrayViewD<'s, &'s str>,
+    );
     type OpOutputs = (ArrayD<f32>, ArrayD<i64>, ArrayD<String>);
 
     fn kernel_create(info: &KernelInfo) -> Result<Self, Self::KernelCreateError> {
@@ -42,7 +46,7 @@ impl CustomOp for AttrShowcase {
     ) -> Result<Self::OpOutputs, Self::ComputeError> {
         let a = &a + self.float_attr;
         let b = &b + self.int_attr;
-        let c = c.mapv_into(|v| v + " + " + &self.string_attr);
+        let c = c.map(|v| v.to_string() + " + " + &self.string_attr);
         Ok((a, b, c))
     }
 }

--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -1,20 +1,20 @@
 use ort_custom_op::prelude::*;
 
 mod add;
-// mod attr_showcase;
-// mod datetime;
-// mod fallible_op;
-// mod sum;
-// mod variadic_identity;
+mod attr_showcase;
+mod datetime;
+mod fallible_op;
+mod sum;
+mod variadic_identity;
 
 /// Static objects defining the custom operators
-// const OP_ATTR_SHOWCASE: OrtCustomOp = build::<attr_showcase::AttrShowcase>();
+const OP_ATTR_SHOWCASE: OrtCustomOp = build::<attr_showcase::AttrShowcase>();
 const OP_CUSTOM_ADD_F32: OrtCustomOp = build::<add::CustomAdd<f32>>();
-// const OP_CUSTOM_ADD_F64: OrtCustomOp = build::<add::CustomAdd<f64>>();
-// const OP_CUSTOM_SUM: OrtCustomOp = build::<sum::CustomSum>();
-// const OP_PARSE_DATETIME: OrtCustomOp = build::<datetime::ParseDateTime>();
-// const OP_VARIADIC_IDENTITY: OrtCustomOp = build::<variadic_identity::VariadicIdentity>();
-// const OP_FALLIBLE: OrtCustomOp = build::<fallible_op::FallibleOp>();
+const OP_CUSTOM_ADD_F64: OrtCustomOp = build::<add::CustomAdd<f64>>();
+const OP_CUSTOM_SUM: OrtCustomOp = build::<sum::CustomSum>();
+const OP_PARSE_DATETIME: OrtCustomOp = build::<datetime::ParseDateTime>();
+const OP_VARIADIC_IDENTITY: OrtCustomOp = build::<variadic_identity::VariadicIdentity>();
+const OP_FALLIBLE: OrtCustomOp = build::<fallible_op::FallibleOp>();
 
 /// Public function which onnxruntime expects to be in the shared library
 #[no_mangle]
@@ -27,13 +27,13 @@ pub extern "C" fn RegisterCustomOps(
         api_base,
         "my.domain",
         &[
-            // &OP_ATTR_SHOWCASE,
+            &OP_ATTR_SHOWCASE,
             &OP_CUSTOM_ADD_F32,
-            // &OP_CUSTOM_ADD_F64,
-            // &OP_CUSTOM_SUM,
-            // &OP_PARSE_DATETIME,
-            // &OP_VARIADIC_IDENTITY,
-            // &OP_FALLIBLE,
+            &OP_CUSTOM_ADD_F64,
+            &OP_CUSTOM_SUM,
+            &OP_PARSE_DATETIME,
+            &OP_VARIADIC_IDENTITY,
+            &OP_FALLIBLE,
         ],
     )
 }

--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -1,20 +1,20 @@
 use ort_custom_op::prelude::*;
 
 mod add;
-mod attr_showcase;
-mod datetime;
-mod fallible_op;
-mod sum;
-mod variadic_identity;
+// mod attr_showcase;
+// mod datetime;
+// mod fallible_op;
+// mod sum;
+// mod variadic_identity;
 
 /// Static objects defining the custom operators
-const OP_ATTR_SHOWCASE: OrtCustomOp = build::<attr_showcase::AttrShowcase>();
+// const OP_ATTR_SHOWCASE: OrtCustomOp = build::<attr_showcase::AttrShowcase>();
 const OP_CUSTOM_ADD_F32: OrtCustomOp = build::<add::CustomAdd<f32>>();
-const OP_CUSTOM_ADD_F64: OrtCustomOp = build::<add::CustomAdd<f64>>();
-const OP_CUSTOM_SUM: OrtCustomOp = build::<sum::CustomSum>();
-const OP_PARSE_DATETIME: OrtCustomOp = build::<datetime::ParseDateTime>();
-const OP_VARIADIC_IDENTITY: OrtCustomOp = build::<variadic_identity::VariadicIdentity>();
-const OP_FALLIBLE: OrtCustomOp = build::<fallible_op::FallibleOp>();
+// const OP_CUSTOM_ADD_F64: OrtCustomOp = build::<add::CustomAdd<f64>>();
+// const OP_CUSTOM_SUM: OrtCustomOp = build::<sum::CustomSum>();
+// const OP_PARSE_DATETIME: OrtCustomOp = build::<datetime::ParseDateTime>();
+// const OP_VARIADIC_IDENTITY: OrtCustomOp = build::<variadic_identity::VariadicIdentity>();
+// const OP_FALLIBLE: OrtCustomOp = build::<fallible_op::FallibleOp>();
 
 /// Public function which onnxruntime expects to be in the shared library
 #[no_mangle]
@@ -27,13 +27,13 @@ pub extern "C" fn RegisterCustomOps(
         api_base,
         "my.domain",
         &[
-            &OP_ATTR_SHOWCASE,
+            // &OP_ATTR_SHOWCASE,
             &OP_CUSTOM_ADD_F32,
-            &OP_CUSTOM_ADD_F64,
-            &OP_CUSTOM_SUM,
-            &OP_PARSE_DATETIME,
-            &OP_VARIADIC_IDENTITY,
-            &OP_FALLIBLE,
+            // &OP_CUSTOM_ADD_F64,
+            // &OP_CUSTOM_SUM,
+            // &OP_PARSE_DATETIME,
+            // &OP_VARIADIC_IDENTITY,
+            // &OP_FALLIBLE,
         ],
     )
 }

--- a/ort-custom-op/src/api.rs
+++ b/ort-custom-op/src/api.rs
@@ -202,14 +202,15 @@ impl OrtKernelContext {
         let mut inputs = Vec::with_capacity(n_inputs);
         for idx in 0..n_inputs {
             let value = self.get_input(api, idx)?;
-            match value.onnx_type(api) {
-                _ => {
+            match value.onnx_type(api)? {
+                ONNXType_ONNX_TYPE_TENSOR => {
                     let (dtype, shape) = {
                         let info = value.get_tensor_type_and_shape(api)?;
                         (info.get_element_type()?, info.shape()?)
                     };
                     inputs.push(value.load_tensor_buffer(api, dtype, shape)?);
                 }
+                _ => bail!("Only tensor inputs are supported."),
             }
         }
         Ok(inputs)

--- a/ort-custom-op/src/api.rs
+++ b/ort-custom-op/src/api.rs
@@ -194,6 +194,7 @@ impl OrtValue {
 }
 
 impl OrtKernelContext {
+    #[allow(non_upper_case_globals)]
     pub(crate) fn get_input_values<'s>(
         &'s self,
         api: &OrtApi,

--- a/ort-custom-op/src/custom_op.rs
+++ b/ort-custom-op/src/custom_op.rs
@@ -24,9 +24,9 @@ pub trait CustomOp {
     fn kernel_create(info: &KernelInfo) -> Result<Self, Self::KernelCreateError>
     where
         Self: Sized;
-    fn kernel_compute<'s>(
+    fn kernel_compute(
         &self,
-        inputs: Self::OpInputs<'s>,
+        inputs: Self::OpInputs<'_>,
     ) -> Result<Self::OpOutputs, Self::ComputeError>;
 }
 
@@ -117,7 +117,7 @@ extern "C" fn get_input_type<T>(_op: *const OrtCustomOp, index: usize) -> ONNXTe
 where
     T: CustomOp,
 {
-    <T::OpInputs<'_>>::tensor_data_type(index).expect(&format!("Input '{}' is not a tensor", index))
+    <T::OpInputs<'_>>::tensor_data_type(index).unwrap_or_else(|| panic!("Input '{}' is not a tensor", index))
 }
 
 extern "C" fn get_input_type_count<T>(_op: *const OrtCustomOp) -> usize

--- a/ort-custom-op/src/custom_op.rs
+++ b/ort-custom-op/src/custom_op.rs
@@ -117,7 +117,8 @@ extern "C" fn get_input_type<T>(_op: *const OrtCustomOp, index: usize) -> ONNXTe
 where
     T: CustomOp,
 {
-    <T::OpInputs<'_>>::tensor_data_type(index).unwrap_or_else(|| panic!("Input '{}' is not a tensor", index))
+    <T::OpInputs<'_>>::tensor_data_type(index)
+        .unwrap_or_else(|| panic!("Input '{}' is not a tensor", index))
 }
 
 extern "C" fn get_input_type_count<T>(_op: *const OrtCustomOp) -> usize
@@ -164,7 +165,7 @@ where
     std::ptr::null_mut()
 }
 
-unsafe extern "C" fn kernel_compute_fallible<'ctx, T>(
+unsafe extern "C" fn kernel_compute_fallible<T>(
     op_kernel: *mut c_void,
     context_ptr: *mut OrtKernelContext,
 ) -> *mut OrtStatus
@@ -174,7 +175,7 @@ where
 {
     let WrappedKernel::<T> { user_kernel, api } = &mut *(op_kernel as *mut _);
 
-    let context = context_ptr.as_mut::<'ctx>().unwrap();
+    let context = context_ptr.as_mut::<'_>().unwrap();
     let outputs = {
         let bufs = bail_on_error!(api, context.get_input_values(api));
         let bufs: Vec<_> = bufs.iter().map(|el| el.normalize_buffers()).collect();

--- a/ort-custom-op/src/custom_op.rs
+++ b/ort-custom-op/src/custom_op.rs
@@ -12,28 +12,34 @@ pub use crate::outputs::Outputs;
 
 /// Trait defining the behavior of a custom operator.
 pub trait CustomOp {
+    /// Error type for the kernel creation
     type KernelCreateError;
+    /// Error type of the compute operation
     type ComputeError;
+    /// Name of the operator
     const NAME: &'static str;
-    /// Minimum number of variadic inputs
+    /// Minimum number of variadic inputs. Any non-zero value requires
+    /// that the last input is variadic.
     const VARIADIC_MIN_ARITY: usize = 0;
 
     type OpInputs<'s>: Inputs<'s>;
     type OpOutputs: Outputs;
 
+    /// Set up state later used in compute calls. Called once per session.
     fn kernel_create(info: &KernelInfo) -> Result<Self, Self::KernelCreateError>
     where
         Self: Sized;
+
     fn kernel_compute(
         &self,
         inputs: Self::OpInputs<'_>,
     ) -> Result<Self::OpOutputs, Self::ComputeError>;
 }
 
-/// Function to build static instances of `OrtCustomOp`.
+/// Function to build static instances of [`OrtCustomOp`].
 ///
-/// These static objects are registered using the
-/// `create_custom_op_domain` function.
+/// The produced static object can be registered using the
+/// [`crate::prelude::create_custom_op_domain`] function.
 pub const fn build<T>() -> OrtCustomOp
 where
     T: CustomOp,

--- a/ort-custom-op/src/custom_op.rs
+++ b/ort-custom-op/src/custom_op.rs
@@ -1,6 +1,5 @@
 use std::ffi::CString;
 use std::os::raw::{c_char, c_void};
-use std::unimplemented;
 
 use crate::api::{KernelInfo, API_VERSION};
 use crate::bindings::{
@@ -9,224 +8,36 @@ use crate::bindings::{
     OrtMemType_OrtMemTypeDefault, OrtStatus,
 };
 pub use crate::outputs::Outputs;
-pub use crate::value::TryFromValues;
-use crate::value::{TryIntoInputTuple, Value};
+pub use crate::value::Inputs;
 
 /// Trait defining the behavior of a custom operator.
-pub trait CustomOp<'s> {
+pub trait CustomOp {
     type KernelCreateError;
     type ComputeError;
     const NAME: &'static str;
 
-    type OpInputs: TryFromValues<'s>;
+    type OpInputs<'s>: Inputs<'s>;
     type OpOutputs: Outputs;
 
     fn kernel_create(info: &KernelInfo) -> Result<Self, Self::KernelCreateError>
     where
         Self: Sized;
-    fn kernel_compute(&self, inputs: Self::OpInputs)
-        -> Result<Self::OpOutputs, Self::ComputeError>;
+    fn kernel_compute<'s>(
+        &self,
+        inputs: Self::OpInputs<'s>,
+    ) -> Result<Self::OpOutputs, Self::ComputeError>;
 }
 
 /// Function to build static instances of `OrtCustomOp`.
 ///
 /// These static objects are registered using the
 /// `create_custom_op_domain` function.
-pub const fn build<'ctx, 'data, T>() -> OrtCustomOp
+pub const fn build<T>() -> OrtCustomOp
 where
-    'ctx: 'data,
-    T: for<'s> CustomOp<'s>,
-    <T as CustomOp<'data>>::KernelCreateError: std::fmt::Display,
-    <T as CustomOp<'data>>::ComputeError: std::fmt::Display,
+    T: CustomOp,
+    T::KernelCreateError: std::fmt::Display,
+    T::ComputeError: std::fmt::Display,
 {
-    extern "C" fn get_name<'s, T>(_op: *const OrtCustomOp) -> *const c_char
-    where
-        T: CustomOp<'s>,
-    {
-        CString::new(T::NAME).unwrap().into_raw()
-    }
-
-    extern "C" fn get_execution_provider_type(_op: *const OrtCustomOp) -> *const c_char {
-        b"CPUExecutionProvider\0".as_ptr() as *const _
-    }
-
-    extern "C" fn get_input_type<'s, T>(
-        _op: *const OrtCustomOp,
-        index: usize,
-    ) -> ONNXTensorElementDataType
-    where
-        T: CustomOp<'s>,
-    {
-        // <<T as CustomOp>::OpInputs as Inputs>::INPUT_TYPES[index].to_ort_encoding()
-        unimplemented!()
-    }
-
-    extern "C" fn get_input_type_count<'s, T>(_op: *const OrtCustomOp) -> usize
-    where
-        T: CustomOp<'s>,
-    {
-        // <<T as CustomOp>::OpInputs as Inputs>::CHARACTERISTICS.len()
-        unimplemented!()
-    }
-
-    extern "C" fn get_output_type<'s, T>(
-        _op: *const OrtCustomOp,
-        index: usize,
-    ) -> ONNXTensorElementDataType
-    where
-        T: CustomOp<'s>,
-    {
-        // <<T as CustomOp>::OpOutputs as Outputs>::OUTPUT_TYPES[index].to_ort_encoding()
-        unimplemented!()
-    }
-
-    extern "C" fn get_output_type_count<'s, T>(_op: *const OrtCustomOp) -> usize
-    where
-        T: CustomOp<'s>,
-    {
-        <<T as CustomOp>::OpOutputs as Outputs>::OUTPUT_TYPES.len()
-    }
-
-    unsafe extern "C" fn create_kernel_fallible<'s, T>(
-        _ort_op: *const OrtCustomOp,
-        ort_api: *const OrtApi,
-        ort_info: *const OrtKernelInfo,
-        kernel: *mut *mut c_void,
-    ) -> *mut OrtStatus
-    where
-        T: CustomOp<'s>,
-        <T as CustomOp<'s>>::KernelCreateError: std::fmt::Display,
-    {
-        let api = &*ort_api;
-        let info = KernelInfo::from_ort(api, &*ort_info);
-        let user_kernel = match T::kernel_create(&info) {
-            Ok(kernel) => kernel,
-            Err(err) => {
-                *kernel = std::ptr::null_mut();
-                // msg is copied inside `CreateStatus`
-                let msg = CString::new(format!("{}: {}", T::NAME, err)).unwrap();
-                return api.CreateStatus.unwrap()(OrtErrorCode_ORT_RUNTIME_EXCEPTION, msg.as_ptr());
-            }
-        };
-        let wrapped_kernel = WrappedKernel { user_kernel, api };
-
-        *kernel = Box::leak(Box::new(wrapped_kernel)) as *mut _ as *mut c_void;
-        std::ptr::null_mut()
-    }
-
-    unsafe extern "C" fn kernel_compute_fallible<'ctx, T>(
-        op_kernel: *mut c_void,
-        context_ptr: *mut OrtKernelContext,
-    ) -> *mut OrtStatus
-    where
-        T: for<'s> CustomOp<'s>,
-        //for<'s> <T as CustomOp<'s>>::ComputeError: std::fmt::Display,
-    {
-        let wrapped_kernel: &mut WrappedKernel<T> = &mut *(op_kernel as *mut _);
-        let kernel = &wrapped_kernel.user_kernel;
-        let api = &wrapped_kernel.api;
-        let context = context_ptr.as_ref::<'ctx>().unwrap();
-
-        let input_values = vec![];
-        // context.get_input_values(api).unwrap();
-        let input_values = input_values.as_slice();
-        let tuple = TryFromValues::try_from_values(input_values).unwrap();
-        let outputs = kernel.kernel_compute(tuple);
-
-        // let outputs = {
-        //     let inputs = <T::OpInputs as Inputs>::from_ort(api, context);
-        //     kernel.kernel_compute(inputs)
-        // };
-
-        match outputs {
-            Ok(outputs) => {
-                // Bad hack to use a second context here! The first one is
-                // still borrowed immutably at this point :/
-                let out_context = context_ptr.as_mut::<'ctx>().unwrap();
-                outputs.write_to_ort(api, out_context);
-                return std::ptr::null_mut();
-            }
-            Err(_err) => {
-                let msg = CString::new(format!("{}: print error", T::NAME)).unwrap();
-                return api.CreateStatus.unwrap()(OrtErrorCode_ORT_RUNTIME_EXCEPTION, msg.as_ptr());
-            }
-        }
-    }
-
-    unsafe extern "C" fn kernel_destroy<'s, T>(op_kernel: *mut c_void)
-    where
-        T: CustomOp<'s>,
-    {
-        drop(Box::from_raw(op_kernel as *mut WrappedKernel<T>));
-    }
-
-    extern "C" fn get_input_characteristic<'s, T>(
-        _op: *const OrtCustomOp,
-        index: usize,
-    ) -> OrtCustomOpInputOutputCharacteristic
-    where
-        T: CustomOp<'s>,
-        // <T as CustomOp>::OpInputs<'s>: Inputs<'s>,
-    {
-        // <<T as CustomOp>::OpInputs<'s> as Inputs>::CHARACTERISTICS[index]
-        unimplemented!()
-    }
-
-    extern "C" fn get_output_characteristic<'s, T>(
-        _op: *const OrtCustomOp,
-        index: usize,
-    ) -> OrtCustomOpInputOutputCharacteristic
-    where
-        T: CustomOp<'s>,
-    {
-        <<T as CustomOp>::OpOutputs as Outputs>::CHARACTERISTICS[index]
-    }
-
-    extern "C" fn get_mem_type_default(_op: *const OrtCustomOp, _index: usize) -> OrtMemType {
-        OrtMemType_OrtMemTypeDefault
-    }
-
-    extern "C" fn get_variadic_input_homogeneity<'s, T>(
-        _op: *const OrtCustomOp,
-    ) -> ::std::os::raw::c_int
-    where
-        T: CustomOp<'s>,
-    {
-        unimplemented!()
-        // i32::from(<<T as CustomOp>::OpInputs<'s> as Inputs>::VARIADIC_IS_HOMOGENEOUS)
-    }
-
-    extern "C" fn get_variadic_input_min_arity<'s, T>(
-        _op: *const OrtCustomOp,
-    ) -> ::std::os::raw::c_int
-    where
-        T: CustomOp<'s>,
-        // <T as CustomOp>::OpInputs<'s>: Inputs<'s>,
-    {
-        unimplemented!()
-        // <<T as CustomOp>::OpInputs<'s> as Inputs>::VARIADIC_MIN_ARITY as _
-    }
-
-    extern "C" fn get_variadic_output_homogeneity<'s, T>(
-        _op: *const OrtCustomOp,
-    ) -> ::std::os::raw::c_int
-    where
-        T: CustomOp<'s>,
-    {
-        i32::from(<<T as CustomOp>::OpOutputs as Outputs>::VARIADIC_IS_HOMOGENEOUS)
-    }
-
-    extern "C" fn get_variadic_output_min_arity<'s, T>(
-        _op: *const OrtCustomOp,
-    ) -> ::std::os::raw::c_int
-    where
-        T: CustomOp<'s>,
-        <T as CustomOp<'s>>::KernelCreateError: std::fmt::Display,
-        <T as CustomOp<'s>>::ComputeError: std::fmt::Display,
-    {
-        <<T as CustomOp>::OpOutputs as Outputs>::VARIADIC_MIN_ARITY as _
-    }
-
     OrtCustomOp {
         // This is the API version, not the version of the
         // operator. It is currently not clear to me how one defines a
@@ -253,7 +64,179 @@ where
     }
 }
 
+/// Conditionaly return with a non-null `OrtStatus` pointer from a result.
+///
+/// Return if the provided result is the error variant. Otherwise,
+/// unwrap the `Ok` value.
+macro_rules! bail_on_error {
+    ($api:expr, $res:expr) => {
+        match $res {
+            Ok(val) => val,
+            Err(err) => {
+                // msg is copied inside `CreateStatus`; no need to leak
+                let msg = CString::new(format!("{}: {}", T::NAME, err)).unwrap();
+                return $api.CreateStatus.unwrap()(
+                    OrtErrorCode_ORT_RUNTIME_EXCEPTION,
+                    msg.as_ptr(),
+                );
+            }
+        }
+    };
+}
+
+/// Helper struct which contains a reference to the api object. We use
+/// it to shuttle a reference to the Api object from the
+/// kernel-creation time to the compute method which would otherwise
+/// have no such reference.
 struct WrappedKernel<T> {
     user_kernel: T,
     api: &'static OrtApi,
+}
+
+extern "C" fn get_name<T>(_op: *const OrtCustomOp) -> *const c_char
+where
+    T: CustomOp,
+{
+    CString::new(T::NAME).unwrap().into_raw()
+}
+
+extern "C" fn get_execution_provider_type(_op: *const OrtCustomOp) -> *const c_char {
+    b"CPUExecutionProvider\0".as_ptr() as *const _
+}
+
+extern "C" fn get_input_type<T>(_op: *const OrtCustomOp, index: usize) -> ONNXTensorElementDataType
+where
+    T: CustomOp,
+{
+    // <T::OpInputs as Inputs>::INPUT_TYPES[index].to_ort_encoding()
+    unimplemented!()
+}
+
+extern "C" fn get_input_type_count<T>(_op: *const OrtCustomOp) -> usize
+where
+    T: CustomOp,
+{
+    // <T::OpInputs as Inputs>::CHARACTERISTICS.len()
+    unimplemented!()
+}
+
+extern "C" fn get_output_type<T>(_op: *const OrtCustomOp, index: usize) -> ONNXTensorElementDataType
+where
+    T: CustomOp,
+{
+    // <T::OpOutputs as Outputs>::OUTPUT_TYPES[index].to_ort_encoding()
+    unimplemented!()
+}
+
+extern "C" fn get_output_type_count<T>(_op: *const OrtCustomOp) -> usize
+where
+    T: CustomOp,
+{
+    <T::OpOutputs as Outputs>::OUTPUT_TYPES.len()
+}
+
+unsafe extern "C" fn create_kernel_fallible<T>(
+    _ort_op: *const OrtCustomOp,
+    ort_api: *const OrtApi,
+    ort_info: *const OrtKernelInfo,
+    kernel: *mut *mut c_void,
+) -> *mut OrtStatus
+where
+    T: CustomOp,
+    T::KernelCreateError: std::fmt::Display,
+{
+    let api = &*ort_api;
+    let info = KernelInfo::from_ort(api, &*ort_info);
+    let user_kernel = bail_on_error!(api, T::kernel_create(&info));
+    let wrapped_kernel = WrappedKernel { user_kernel, api };
+
+    // Kernel is later destroyed in `kernel_destroy`
+    *kernel = Box::leak(Box::new(wrapped_kernel)) as *mut _ as *mut c_void;
+    std::ptr::null_mut()
+}
+
+unsafe extern "C" fn kernel_compute_fallible<'ctx, T>(
+    op_kernel: *mut c_void,
+    context_ptr: *mut OrtKernelContext,
+) -> *mut OrtStatus
+where
+    T: CustomOp,
+    T::ComputeError: std::fmt::Display,
+{
+    let WrappedKernel::<T> { user_kernel, api } = &mut *(op_kernel as *mut _);
+
+    let context = context_ptr.as_mut::<'ctx>().unwrap();
+    let outputs = {
+        let input_values = bail_on_error!(api, context.get_input_values(api));
+        let input_values = input_values.as_slice();
+        let tuple = bail_on_error!(api, Inputs::try_from_values(input_values));
+        bail_on_error!(api, user_kernel.kernel_compute(tuple))
+    };
+
+    outputs.write_to_ort(api, context);
+    std::ptr::null_mut()
+}
+
+unsafe extern "C" fn kernel_destroy<T>(op_kernel: *mut c_void)
+where
+    T: CustomOp,
+{
+    drop(Box::from_raw(op_kernel as *mut WrappedKernel<T>));
+}
+
+extern "C" fn get_input_characteristic<T>(
+    _op: *const OrtCustomOp,
+    index: usize,
+) -> OrtCustomOpInputOutputCharacteristic
+where
+    T: CustomOp,
+    // T::OpInputs<'s>: Inputs<'s>,
+{
+    // <T::OpInputs<'s> as Inputs>::CHARACTERISTICS[index]
+    unimplemented!()
+}
+
+extern "C" fn get_output_characteristic<T>(
+    _op: *const OrtCustomOp,
+    index: usize,
+) -> OrtCustomOpInputOutputCharacteristic
+where
+    T: CustomOp,
+{
+    <T::OpOutputs as Outputs>::CHARACTERISTICS[index]
+}
+
+extern "C" fn get_mem_type_default(_op: *const OrtCustomOp, _index: usize) -> OrtMemType {
+    OrtMemType_OrtMemTypeDefault
+}
+
+extern "C" fn get_variadic_input_homogeneity<T>(_op: *const OrtCustomOp) -> ::std::os::raw::c_int
+where
+    T: CustomOp,
+{
+    unimplemented!()
+    // i32::from(<T::OpInputs<'s> as Inputs>::VARIADIC_IS_HOMOGENEOUS)
+}
+
+extern "C" fn get_variadic_input_min_arity<T>(_op: *const OrtCustomOp) -> ::std::os::raw::c_int
+where
+    T: CustomOp,
+    // T::OpInputs<'s>: Inputs<'s>,
+{
+    unimplemented!()
+    // <T::OpInputs<'s> as Inputs>::VARIADIC_MIN_ARITY as _
+}
+
+extern "C" fn get_variadic_output_homogeneity<T>(_op: *const OrtCustomOp) -> ::std::os::raw::c_int
+where
+    T: CustomOp,
+{
+    i32::from(T::OpOutputs::VARIADIC_IS_HOMOGENEOUS)
+}
+
+extern "C" fn get_variadic_output_min_arity<T>(_op: *const OrtCustomOp) -> ::std::os::raw::c_int
+where
+    T: CustomOp,
+{
+    T::OpOutputs::VARIADIC_MIN_ARITY as _
 }

--- a/ort-custom-op/src/custom_op.rs
+++ b/ort-custom-op/src/custom_op.rs
@@ -232,7 +232,7 @@ where
 {
     i32::from(
         <T::OpInputs<'_>>::VARIADIC_IS_HOMOGENEOUS
-            .expect("'get_variadic_input_homogeneity' was for operator with fixed arity."),
+            .expect("'get_variadic_input_homogeneity' was called for operator with fixed arity."),
     )
 }
 

--- a/ort-custom-op/src/inputs.rs
+++ b/ort-custom-op/src/inputs.rs
@@ -33,7 +33,7 @@ pub trait Inputs<'a>: Sized {
     }
 }
 
-trait TryFromValue<'s>: Sized {
+pub trait TryFromValue<'s>: Sized {
     fn try_from_value(value: Value<'s>) -> Result<Self>;
 }
 

--- a/ort-custom-op/src/inputs.rs
+++ b/ort-custom-op/src/inputs.rs
@@ -9,7 +9,7 @@ use ndarray::{ArrayD, ArrayViewD};
 
 /// Trait which qualifies types to be used as input to the
 /// `kernel_compute` function of the custom operator.
-pub trait Inputs<'s> {
+trait Inputs<'s> {
     const CHARACTERISTICS: &'static [OrtCustomOpInputOutputCharacteristic];
 
     // TODO: Make this configurable? Why does this even exists?!

--- a/ort-custom-op/src/inputs.rs
+++ b/ort-custom-op/src/inputs.rs
@@ -7,6 +7,14 @@ use crate::value::Value;
 use anyhow::{bail, Result};
 use ndarray::ArrayViewD;
 
+/// Trait defining which types can be used as inputs when implementing [crate::prelude::CustomOp].
+///
+/// Currently, `Inputs` is implemented for tuples of up to ten
+/// elements of of [ArrayViewD] with element types `u8`,
+/// `u16`, `u32`, `u64`, `i8`, `i16`, `i32`, `i64`, `bool`, and
+/// `&str`. Furthermore, the last element of the tuple may be
+/// variadic by being a `Vec` of [ArrayViewD] objects with one of the
+/// previously stated element types.
 pub trait Inputs<'a>: Sized {
     /// Is the variadic part of the inputs (if any) homogeneous?
     const VARIADIC_IS_HOMOGENEOUS: Option<bool>;

--- a/ort-custom-op/src/inputs.rs
+++ b/ort-custom-op/src/inputs.rs
@@ -11,7 +11,7 @@ use ndarray::ArrayViewD;
 ///
 /// Currently, `Inputs` is implemented for tuples of up to ten
 /// elements of of [ArrayViewD] with element types `u8`,
-/// `u16`, `u32`, `u64`, `i8`, `i16`, `i32`, `i64`, `bool`, and
+/// `u16`, `u32`, `u64`, `i8`, `i16`, `i32`, `i64`, `f32`, `f64`, `bool`, and
 /// `&str`. Furthermore, the last element of the tuple may be
 /// variadic by being a `Vec` of [ArrayViewD] objects with one of the
 /// previously stated element types.

--- a/ort-custom-op/src/lib.rs
+++ b/ort-custom-op/src/lib.rs
@@ -10,7 +10,6 @@ pub mod prelude {
     pub use crate::api::{create_custom_op_domain, KernelInfo};
     pub use crate::bindings::{OrtApiBase, OrtCustomOp, OrtSessionOptions, OrtStatus};
     pub use crate::custom_op::{build, CustomOp};
-    pub use crate::inputs::Inputs;
     pub use crate::outputs::Outputs;
-    pub use crate::value::TryFromValues;
+    pub use crate::value::Inputs;
 }

--- a/ort-custom-op/src/lib.rs
+++ b/ort-custom-op/src/lib.rs
@@ -12,4 +12,5 @@ pub mod prelude {
     pub use crate::custom_op::{build, CustomOp};
     pub use crate::inputs::Inputs;
     pub use crate::outputs::Outputs;
+    pub use crate::value::TryFromValues;
 }

--- a/ort-custom-op/src/lib.rs
+++ b/ort-custom-op/src/lib.rs
@@ -10,6 +10,7 @@ pub mod prelude {
     pub use crate::api::{create_custom_op_domain, KernelInfo};
     pub use crate::bindings::{OrtApiBase, OrtCustomOp, OrtSessionOptions, OrtStatus};
     pub use crate::custom_op::{build, CustomOp};
+    pub use crate::inputs::Inputs;
     pub use crate::outputs::Outputs;
-    pub use crate::value::Inputs;
+    pub use crate::value::Value;
 }

--- a/ort-custom-op/src/lib.rs
+++ b/ort-custom-op/src/lib.rs
@@ -4,6 +4,7 @@ mod custom_op;
 mod error;
 mod inputs;
 mod outputs;
+mod value;
 
 pub mod prelude {
     pub use crate::api::{create_custom_op_domain, KernelInfo};

--- a/ort-custom-op/src/outputs.rs
+++ b/ort-custom-op/src/outputs.rs
@@ -39,7 +39,7 @@ macro_rules! impl_output_non_string {
                 let shape = self.shape();
                 let shape_i64: Vec<_> = shape.iter().map(|v| *v as i64).collect();
                 let val = unsafe { ctx.get_output(api, idx, &shape_i64) }.unwrap();
-                let mut arr = val.as_array_mut(api).unwrap();
+                let mut arr = unsafe { val.as_array_mut(api).unwrap() };
                 arr.assign(&self);
             }
         }

--- a/ort-custom-op/src/outputs.rs
+++ b/ort-custom-op/src/outputs.rs
@@ -84,7 +84,6 @@ macro_rules! impl_outputs {
                 $(<$param as Output>::OUTPUT_TYPE,)* $last_param::OUTPUT_TYPE
             ];
 
-
             fn write_to_ort(self, api: &OrtApi, ctx: &mut OrtKernelContext,) {
                 $(self.$idx.write_to_ort(api, ctx, $idx);)*
                 self.$last_idx.write_to_ort(api, ctx, $last_idx);
@@ -108,7 +107,7 @@ impl_outputs! {(0: A, 1: B, 2: C, 3: D, 4: E, 5: F, 6: G, 7: H, 8: I, 9: J )| 10
 trait LastOutput {
     const CHARACTERISTIC: OrtCustomOpInputOutputCharacteristic;
 
-    // TODO: Make this configurable?
+    // TODO: min arity should not be defined here but in the user-impl of CustomOp
     const VARIADIC_MIN_ARITY: usize = 1;
     const VARIADIC_IS_HOMOGENEOUS: bool;
     const OUTPUT_TYPE: ElementType;

--- a/ort-custom-op/src/value.rs
+++ b/ort-custom-op/src/value.rs
@@ -57,7 +57,7 @@ pub(crate) enum BufferMaybeOwned<'s> {
 }
 
 /// Object owning the contiguous String buffer.
-struct StringBuffer {
+pub(crate) struct StringBuffer {
     buf: Vec<u8>,
     offsets: Vec<usize>,
 }

--- a/ort-custom-op/src/value.rs
+++ b/ort-custom-op/src/value.rs
@@ -1,0 +1,205 @@
+use anyhow::{bail, Result};
+use ndarray::{Array, ArrayD, ArrayViewD};
+
+#[derive(Debug)]
+pub enum Value<'a> {
+    TensorBool(ArrayViewD<'a, bool>),
+    TensorF32(ArrayViewD<'a, f32>),
+    TensorF64(ArrayViewD<'a, f64>),
+    TensorI16(ArrayViewD<'a, i16>),
+    TensorI32(ArrayViewD<'a, i32>),
+    TensorI64(ArrayViewD<'a, i64>),
+    TensorI8(ArrayViewD<'a, i8>),
+    TensorU16(ArrayViewD<'a, u16>),
+    TensorU32(ArrayViewD<'a, u32>),
+    TensorU64(ArrayViewD<'a, u64>),
+    TensorU8(ArrayViewD<'a, u8>),
+
+    TensorString(TensorString),
+}
+
+#[derive(Debug)]
+pub struct TensorString {
+    pub buf: Vec<u8>,
+    pub offsets: Vec<usize>,
+    pub shape: Vec<usize>,
+}
+
+impl TensorString {
+    fn as_owned_array(&self) -> Result<ArrayD<&str>> {
+        // Compute windows with the start and end of each
+        // substring and then scan the buffer.
+        let very_end = [self.buf.len()];
+        let starts = self.offsets.iter();
+        let ends = self.offsets.iter().chain(very_end.iter()).skip(1);
+        let windows = starts.zip(ends);
+        let strings: Vec<_> = windows
+            .scan(self.buf.as_slice(), |buf: &mut &[u8], (start, end)| {
+                let (this, rest) = buf.split_at(end - start);
+                *buf = rest;
+                std::str::from_utf8(this).ok()
+            })
+            .collect();
+
+        Ok(Array::from_vec(strings)
+            .into_shape(self.shape.as_slice())
+            .expect("Shape information was incorrect."))
+    }
+}
+
+impl<'a> TryFrom<&'a Value<'_>> for ArrayD<&'a str> {
+    type Error = anyhow::Error;
+
+    fn try_from(value: &'a Value<'_>) -> std::result::Result<Self, Self::Error> {
+        if let Value::TensorString(tensor_string) = value {
+            Ok(tensor_string.as_owned_array()?)
+        } else {
+            bail!("Expected 'String' tensor, found {:?}", value)
+        }
+    }
+}
+
+macro_rules! impl_try_from {
+    ($ty:ty, $variant:path) => {
+        impl<'a, 'b> TryFrom<&'a Value<'_>> for ArrayViewD<'b, $ty>
+        where
+            'a: 'b,
+        {
+            type Error = anyhow::Error;
+
+            fn try_from(value: &'a Value<'_>) -> std::result::Result<Self, Self::Error> {
+                if let $variant(arr) = value {
+                    Ok(arr.view())
+                } else {
+                    bail!("Expected '{}' tensor, found {:?}", stringify!($ty), value)
+                }
+            }
+        }
+    };
+}
+
+impl_try_from!(u8, Value::TensorU8);
+impl_try_from!(u64, Value::TensorU64);
+impl_try_from!(u32, Value::TensorU32);
+impl_try_from!(u16, Value::TensorU16);
+impl_try_from!(i8, Value::TensorI8);
+impl_try_from!(i64, Value::TensorI64);
+impl_try_from!(i32, Value::TensorI32);
+impl_try_from!(i16, Value::TensorI16);
+impl_try_from!(f64, Value::TensorF64);
+impl_try_from!(f32, Value::TensorF32);
+
+pub trait TryIntoInputTuple<TPL> {
+    fn try_into_tuple(self) -> Result<TPL>;
+}
+
+// This can be implemented using the macro, but would require adding exceptions for warnings
+impl<'a, 'b, A> TryIntoInputTuple<(Vec<A>,)> for &'b [Value<'a>]
+where
+    'a: 'b,
+    A: TryFrom<&'b Value<'a>, Error = anyhow::Error>,
+{
+    fn try_into_tuple(self) -> Result<(Vec<A>,)> {
+        let rest = self
+            .iter()
+            .map(|el| el.try_into().map_err(|e| anyhow::anyhow!("{:?}", e)))
+            .collect::<Result<_, _>>()?;
+
+        Ok((rest,))
+    }
+}
+
+macro_rules! impl_try_into_input_tuple {
+    ($n_min:literal, $is_variadic:literal, $($var_ty:ident)? | $($positional_ty:ident),*) => {
+        impl<'a, 'b, $($positional_ty,)* $($var_ty)*> TryIntoInputTuple<($($positional_ty,)* $(Vec<$var_ty>,)*)> for &'b[Value<'a>]
+        where
+            'a: 'b,
+            $($positional_ty: TryFrom<&'b Value<'a>, Error = anyhow::Error>,)*
+            $($var_ty: TryFrom<&'b Value<'a>, Error = anyhow::Error>,)*
+        {
+            fn try_into_tuple(self) -> Result<($($positional_ty,)* $(Vec<$var_ty>,)*)> {
+                if $is_variadic {
+                    if self.len() < $n_min {
+                        bail!("expected at least {} inputs; found {}", $n_min, self.len())
+                    }
+                } else if self.len() != $n_min {
+                    bail!("expected {} inputs; found {}", $n_min, self.len())
+                }
+
+                let mut iter = self.iter();
+
+                Ok((
+                    $(TryInto::<$positional_ty>::try_into(iter.next().unwrap())?,)*
+                        $(iter.map(|el| el.try_into()).collect::<Result<Vec<$var_ty>, _>>()?,)*
+                ))
+            }
+        }
+    };
+}
+
+// Positional-only implementations
+impl_try_into_input_tuple!(1, false, | A);
+impl_try_into_input_tuple!(2, false, | A, B);
+impl_try_into_input_tuple!(3, false, | A, B, C);
+impl_try_into_input_tuple!(4, false, | A, B, C, D);
+impl_try_into_input_tuple!(5, false, | A, B, C, D, E);
+impl_try_into_input_tuple!(6, false, | A, B, C, D, E, F);
+impl_try_into_input_tuple!(7, false, | A, B, C, D, E, F, G);
+impl_try_into_input_tuple!(8, false, | A, B, C, D, E, F, G, H);
+impl_try_into_input_tuple!(9, false, | A, B, C, D, E, F, G, H, I);
+impl_try_into_input_tuple!(10, false, | A, B, C, D, E, F, G, H, I, J);
+
+// Variadic implementations; variadic input must be homogeneous, but may be empty
+impl_try_into_input_tuple!(1, true, Z | A);
+impl_try_into_input_tuple!(2, true, Z | A, B);
+impl_try_into_input_tuple!(3, true, Z | A, B, C);
+impl_try_into_input_tuple!(4, true, Z | A, B, C, D);
+impl_try_into_input_tuple!(5, true, Z | A, B, C, D, E);
+impl_try_into_input_tuple!(6, true, Z | A, B, C, D, E, F);
+impl_try_into_input_tuple!(7, true, Z | A, B, C, D, E, F, G);
+impl_try_into_input_tuple!(8, true, Z | A, B, C, D, E, F, G, H);
+impl_try_into_input_tuple!(9, true, Z | A, B, C, D, E, F, G, H, I);
+impl_try_into_input_tuple!(10, true, Z | A, B, C, D, E, F, G, H, I, J);
+
+// impl<'a, A> TryIntoInputTuple<(A,)> for Vec<Value<'a>>
+// where
+//     A: for<'b> TryFrom<&'b Value<'a>, Error = anyhow::Error>,
+// {
+//     fn try_into_tuple(&self) -> Result<(A,)> {
+//         let is_variadic = false;
+//         let n_min = 1;
+
+//         if is_variadic {
+//             if self.len() < n_min {
+//                 bail!("expected at least {} inputs; found {}", n_min, self.len())
+//             }
+//         } else if self.len() != n_min {
+//             bail!("expected {} inputs; found {}", n_min, self.len())
+//         }
+
+//         let mut iter = self.iter();
+
+//         Ok((iter.next().unwrap().try_into()?,))
+//     }
+// }
+
+// impl<'a, A, Z> TryIntoInputTuple<(A, Vec<Z>)> for Vec<Value<'a>>
+// where
+//     A: for<'b> TryFrom<&'b Value<'a>, Error = anyhow::Error>,
+//     Z: for<'b> TryFrom<&'b Value<'a>, Error = anyhow::Error>,
+// {
+//     fn try_into_tuple(&self) -> Result<(A, Vec<Z>)> {
+//         let n_min = 1;
+
+//         if self.len() < n_min {
+//             bail!("expected at least {} inputs; found {}", n_min, self.len())
+//         }
+
+//         let mut iter = self.iter();
+
+//         Ok((
+//             iter.next().unwrap().try_into()?,
+//             iter.map(|el| el.try_into()).collect::<Result<_, _>>()?,
+//         ))
+//     }
+// }

--- a/ort-custom-op/src/value.rs
+++ b/ort-custom-op/src/value.rs
@@ -56,14 +56,16 @@ pub(crate) enum BufferMaybeOwned<'s> {
     String(StringBuffer),
 }
 
-/// Object owning the contiguous String buffer.
+/// Object owning the contiguous String buffer and the associated offsets.
 pub(crate) struct StringBuffer {
     buf: Vec<u8>,
     offsets: Vec<usize>,
 }
 
 impl<'s> BufferMaybeOwned<'s> {
-    pub fn load_from_ort(
+    /// Load data from `OrtValue`. It is the callers responsibility to
+    /// ensure that the `dtype` is correct.
+    pub unsafe fn load_from_ort(
         api: &OrtApi,
         ort_value: &'s mut OrtValue,
         dtype: &ElementType,


### PR DESCRIPTION
Previously, string input tensors had the element type `String` meaning that each string was individually allocated on the heap. Unsurprisingly, this turned out to be a performance issue. 

Strings are rather different to work with than numerical tensors. The latter can be accessed via a slice that lives on the onnxruntime side without a copy. Strings, on the other hand, can only be accessed by allocating a buffer on the Rust side into which all strings are copied back-to-back as one contiguous block. The offsets of the strings are loaded separately. This creates some tricky ownership issues when attempting to unify the API between string and numerical input. The result is that we have to load the data into an enum on the Rust side which we then normalize so that every input is available as a slice with the same lifetime. From these slices we are then free to create `ArrayViewD` objects. This dance can be observed [here](https://github.com/cbourjau/ort-custom-op/compare/master...borrow-string-inputs#diff-ba48c017c5fde0ad5ca126d2efde35a4b83cfbc3cc330673c6bb7c0450a824e4R185-R190).

Note that after this refactoring `&str` input is also passed as `ArrayViewD` rather than an owned array as it used to be. The level of breaking changes can be gauged by the updates to the examples. It is rather straightforward to update. 


