### PR TITLE
Fix crash on zero-sized inputs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,14 @@
 Changelog
 =========
 
+0.7.2 (unreleased)
+------------------
+
+**Bug fix**
+
+- Fix crash when custom operators received input with a zero-sized dimension.
+
+
 0.7.1 (2024-07-04)
 ------------------
 

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -12,4 +12,4 @@ crate-type = ["cdylib"]
 anyhow = "1.0.71"
 chrono = "0.4.23"
 ndarray = "0.15.6"
-ort_custom_op = "0.7"
+ort_custom_op = {"path"= "../ort-custom-op"}

--- a/ort-custom-op/src/api.rs
+++ b/ort-custom-op/src/api.rs
@@ -129,7 +129,10 @@ impl OrtValue {
             let info = self.get_tensor_type_and_shape(api)?;
             info.get_tensor_shape_element_count()?
         };
-
+        if element_count == 0 {
+            // Zero-sized tensor
+            return Ok([].as_mut_slice());
+        }
         let fun = api.GetTensorMutableData.unwrap();
         let mut ptr: *mut _ = std::ptr::null_mut();
         let data = unsafe {

--- a/tests/python/test_custom.py
+++ b/tests/python/test_custom.py
@@ -370,3 +370,28 @@ def test_fail_compute(shared_lib):
 
     # Don't fail depending on input
     sess.run(None, {"fail": np.array(False)})
+
+
+def test_zero_size_input_numeric(shared_lib, variadic_identity_model):
+    sess = setup_session(shared_lib, variadic_identity_model)
+    # Run with input data
+    input_feed = {
+        "A": np.array([], np.float32),
+        "B": np.array([], np.float32),
+    }
+    c, d = sess.run(None, input_feed)
+    a, b = input_feed.values()
+    np.testing.assert_equal(a, c)
+    np.testing.assert_equal(b, d)
+
+def test_zero_size_input_strings(shared_lib, parse_datetime_model):
+    sess = setup_session(shared_lib, parse_datetime_model)
+    # Run with input data
+    input_feed = {
+        sess.get_inputs()[0]
+        .name: np.array([], dtype=str).astype(np.str_),
+    }
+    output_name = sess.get_outputs()[0].name
+    res = sess.run([output_name], input_feed)
+    output_expected = np.array([])
+    np.testing.assert_equal(output_expected, res[0])


### PR DESCRIPTION
Fix crash caused by zero-sized inputs to a custom operator. 

If a tensor is zero-sized it appears to never have an allocation associated with it in the onnxruntime. Thus, the pointer returned by `GetTensorMutableData` remains a null point causing a subsequent crash. The mitigation is simply checking if we expect the tensor to have zero elements.